### PR TITLE
Remove notice of June 1st, 2023 update

### DIFF
--- a/Privacy_Policies/dtbot_privacy_policy.html
+++ b/Privacy_Policies/dtbot_privacy_policy.html
@@ -8,8 +8,6 @@
         <h1>Privacy Policy for DTbot</h1>
 
         <p>Last updated: April 23, 2023<br>Effective: June 1, 2023</p>
-        
-        <h4>NOTE: This Privacy Policy version will be effective June 1st, 2023! To see the currently effective version, head to our <a href="dtbot_privacy_policy_before_2023-06-01.html">current Privacy Policy, effective until the End of May 2023.</a></h4>
 
         <p>At DTbot, a Discord Bot, one of our main priorities is the privacy of our visitors. This Privacy Policy document contains types of information that is collected and recorded by DTbot and how we use it.</p>
 


### PR DESCRIPTION
The Privacy Policy went into effect as scheduled on June 1st, 2023. 

Regrettably, this section was not removed in step with the update. The section linking to the previous Privacy Policy should have been removed in particular, as it (now incorrectly) identifies the superseded Policy as “current”.

As this edit does not affect the Privacy Policy in its substance, this Pull Request will only be kept open for 7 Days (until 2023-07-21 at 00:00 UTC) and not reflected in the “Last updated” and “Effective” dates.